### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ mo-threads>=1.7
 jx_python
 toposort
 whatthepatch
-flask
+Flask
 beautifulsoup4
 psutil
 objgraph


### PR DESCRIPTION
In requirement.txt, Flask module has name 'flask' It can give an error. The correct name for module is "Flask" according to [pypi.org](https://pypi.org/project/Flask/)