### PR TITLE
remove the use of recompute_table_revnums function

### DIFF
--- a/tests/test_clogger.py
+++ b/tests/test_clogger.py
@@ -390,8 +390,11 @@ def test_get_revnum_range_backfill(clogger):
 
     assert len(revnums) == 11
 
+    curr_revnum = rev1 - 11
     for revnum, revision in revnums:
         assert revision
+        assert revnum > curr_revnum
+        curr_revnum = revnum
 
 
 def test_get_revnum_range_tipfill(clogger):
@@ -404,6 +407,7 @@ def test_get_revnum_range_tipfill(clogger):
     # revnum range up to a known revision
     with clogger.conn.transaction() as t:
         tip_num, tip_rev = clogger.get_tip(t)
+        tail_num, _ = clogger.get_tail(t)
         t.execute(
             "DELETE FROM csetLog WHERE revnum >= " + str(tip_num) + " - 5"
         )
@@ -416,8 +420,11 @@ def test_get_revnum_range_tipfill(clogger):
 
     assert len(revnums) == 7
 
+    curr_revnum = tail_num - 1
     for revnum, revision in revnums:
         assert revision
+        assert revnum > curr_revnum
+        curr_revnum = revnum
 
 
 def test_get_revnum_range_tipnback(clogger):
@@ -465,5 +472,8 @@ def test_get_revnum_range_tipnback(clogger):
 
         assert len(revnums) == expected_total_revs
 
+        curr_revnum = rev1 - 11
         for revnum, revision in revnums:
             assert revision
+            assert revnum > curr_revnum
+            curr_revnum = revnum

--- a/tests/test_clogger.py
+++ b/tests/test_clogger.py
@@ -114,9 +114,9 @@ def test_backfilling_to_revision(clogger):
     assert new_old_rev == new_ending
 
     # Check that revnum's were properly handled
-    expected_revnum = oldest_revnum + num_to_go_back
+    expected_revnum = oldest_revnum - num_to_go_back
     with clogger.conn.transaction() as t:
-        new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (oldest_rev,))[0]
+        new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
     assert expected_revnum == new_revnum
 
 
@@ -149,7 +149,7 @@ def test_backfilling_by_count(clogger):
             new_ending = t.get_one("SELECT min(revnum) AS revnum, revision FROM csetLog")[1]
             DEBUG and Log.note("{{data}}", data=(oldest_rev, new_old_rev, new_ending))
             if new_ending == new_old_rev:
-                new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (oldest_rev,))[0]
+                new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
                 break
         if new_ending != new_old_rev:
             Till(seconds=wait_time).wait()
@@ -159,7 +159,7 @@ def test_backfilling_by_count(clogger):
     assert new_old_rev == new_ending
 
     # Check that revnum's were properly handled
-    expected_revnum = oldest_revnum + num_to_go_back
+    expected_revnum = oldest_revnum - num_to_go_back
     assert expected_revnum == new_revnum
 
 
@@ -342,8 +342,8 @@ def test_partial_tipfilling(clogger):
             "DELETE FROM csetLog WHERE revnum >= " + str(max_tip_num) + " - 5"
         )
 
-    with clogger.working_locker:
-        clogger.recompute_table_revnums()
+    #with clogger.working_locker:
+    #    clogger.recompute_table_revnums()
 
     clogger.disable_tipfilling = False
     tmp_num_trys = 0
@@ -386,8 +386,8 @@ def test_get_revnum_range_backfill(clogger):
     curr_revnum = -1
     for revnum, revision in revnums:
         assert revision
-        assert revnum > curr_revnum
-        curr_revnum = revnum
+        # assert revnum > curr_revnum
+        # curr_revnum = revnum
 
 
 def test_get_revnum_range_tipfill(clogger):
@@ -415,8 +415,8 @@ def test_get_revnum_range_tipfill(clogger):
     curr_revnum = -1
     for revnum, revision in revnums:
         assert revision
-        assert revnum > curr_revnum
-        curr_revnum = revnum
+        #assert revnum > curr_revnum
+        #curr_revnum = revnum
 
 
 def test_get_revnum_range_tipnback(clogger):
@@ -467,5 +467,5 @@ def test_get_revnum_range_tipnback(clogger):
         curr_revnum = -1
         for revnum, revision in revnums:
             assert revision
-            assert revnum > curr_revnum
-            curr_revnum = revnum
+            #assert revnum > curr_revnum
+            #curr_revnum = revnum

--- a/tests/test_clogger.py
+++ b/tests/test_clogger.py
@@ -342,9 +342,6 @@ def test_partial_tipfilling(clogger):
             "DELETE FROM csetLog WHERE revnum >= " + str(max_tip_num) + " - 5"
         )
 
-    #with clogger.working_locker:
-    #    clogger.recompute_table_revnums()
-
     clogger.disable_tipfilling = False
     tmp_num_trys = 0
     while tmp_num_trys < num_trys:
@@ -383,11 +380,8 @@ def test_get_revnum_range_backfill(clogger):
 
     assert len(revnums) == 11
 
-    curr_revnum = -1
     for revnum, revision in revnums:
         assert revision
-        # assert revnum > curr_revnum
-        # curr_revnum = revnum
 
 
 def test_get_revnum_range_tipfill(clogger):
@@ -412,11 +406,8 @@ def test_get_revnum_range_tipfill(clogger):
 
     assert len(revnums) == 7
 
-    curr_revnum = -1
     for revnum, revision in revnums:
         assert revision
-        #assert revnum > curr_revnum
-        #curr_revnum = revnum
 
 
 def test_get_revnum_range_tipnback(clogger):
@@ -464,8 +455,5 @@ def test_get_revnum_range_tipnback(clogger):
 
         assert len(revnums) == expected_total_revs
 
-        curr_revnum = -1
         for revnum, revision in revnums:
             assert revision
-            #assert revnum > curr_revnum
-            #curr_revnum = revnum

--- a/tests/test_clogger.py
+++ b/tests/test_clogger.py
@@ -113,11 +113,16 @@ def test_backfilling_to_revision(clogger):
     assert num_trys > 0
     assert new_old_rev == new_ending
 
-    # Check that revnum's were properly handled
-    expected_revnum = oldest_revnum - num_to_go_back
+    expected_old_revnum = oldest_revnum
     with clogger.conn.transaction() as t:
-        new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
-    assert expected_revnum == new_revnum
+        old_oldest_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (oldest_rev,))[0]
+    assert expected_old_revnum == old_oldest_revnum
+
+    # Check that revnum's were properly handled
+    expected_new_revnum = oldest_revnum - num_to_go_back
+    with clogger.conn.transaction() as t:
+        new_oldest_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
+    assert expected_new_revnum == new_oldest_revnum
 
 
 def test_backfilling_by_count(clogger):
@@ -143,13 +148,15 @@ def test_backfilling_by_count(clogger):
     clogger.csets_todo_backwards.add((num_to_go_back, True))
 
     new_ending = None
-    new_revnum = None
+    old_oldest_revnum = None
+    new_oldest_revnum = None
     while num_trys > 0:
         with clogger.conn.transaction() as t:
             new_ending = t.get_one("SELECT min(revnum) AS revnum, revision FROM csetLog")[1]
             DEBUG and Log.note("{{data}}", data=(oldest_rev, new_old_rev, new_ending))
             if new_ending == new_old_rev:
-                new_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
+                old_oldest_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (oldest_rev,))[0]
+                new_oldest_revnum = t.get_one("SELECT revnum FROM csetLog WHERE revision=?", (new_ending,))[0]
                 break
         if new_ending != new_old_rev:
             Till(seconds=wait_time).wait()
@@ -158,9 +165,12 @@ def test_backfilling_by_count(clogger):
     assert num_trys > 0
     assert new_old_rev == new_ending
 
+    expected_old_revnum = oldest_revnum
+    assert expected_old_revnum == old_oldest_revnum
+
     # Check that revnum's were properly handled
-    expected_revnum = oldest_revnum - num_to_go_back
-    assert expected_revnum == new_revnum
+    expected_new_revnum = oldest_revnum - num_to_go_back
+    assert expected_new_revnum == new_oldest_revnum
 
 
 def test_maintenance_and_deletion(clogger):

--- a/tuid/clogger.py
+++ b/tuid/clogger.py
@@ -314,7 +314,7 @@ class Clogger:
                 )
 
             # Move the revision numbers forward if needed
-            self.recompute_table_revnums()
+            #self.recompute_table_revnums()
 
         # Start a maintenance run if needed
         if self.check_for_maintenance():
@@ -786,7 +786,7 @@ class Clogger:
                         )
 
                     # Recalculate the revnums
-                    self.recompute_table_revnums()
+                    #self.recompute_table_revnums()
             except Exception as e:
                 Log.warning("Unexpected error occured while deleting from csetLog:", cause=e)
                 Till(seconds=CSET_DELETION_WAIT_TIME).wait()
@@ -802,10 +802,10 @@ class Clogger:
             with self.conn.transaction() as t:
                 revnum = self._get_one_revnum(t, revision)
 
-            if revnum and revnum[0] >= 0:
+            if revnum:
                 break
-            elif revnum[0] < 0:
-                Log.note("Waiting for table to recompute...")
+            #elif revnum[0] < 0:
+            #    Log.note("Waiting for table to recompute...")
             else:
                 Log.note("Waiting for backfill to complete...")
             Till(seconds=CSET_BACKFILL_WAIT_TIME).wait()

--- a/tuid/clogger.py
+++ b/tuid/clogger.py
@@ -216,34 +216,6 @@ class Clogger:
         ).data
 
 
-    def recompute_table_revnums(self):
-        '''
-        Recomputes the revnums for the csetLog table
-        by creating a new table, and copying csetLog to
-        it. The INTEGER PRIMARY KEY in the temp table auto increments
-        as rows are added.
-
-        IMPORTANT: Only call this after acquiring the
-                   lock `self.working_locker`.
-        :return:
-        '''
-        with self.conn.transaction() as t:
-            t.execute('''
-            CREATE TABLE temp (
-                revnum         INTEGER PRIMARY KEY,
-                revision       CHAR(12) NOT NULL,
-                timestamp      INTEGER
-            );''')
-
-            t.execute(
-                "INSERT INTO temp (revision, timestamp) "
-                "SELECT revision, timestamp FROM csetlog ORDER BY revnum ASC"
-            )
-
-            t.execute("DROP TABLE csetLog;")
-            t.execute("ALTER TABLE temp RENAME TO csetLog;")
-
-
     def check_for_maintenance(self):
         '''
         Returns True if the maintenance worker should be run now,
@@ -312,9 +284,6 @@ class Clogger:
                         for revnum, revision, timestamp in tmp_insert_list
                     )
                 )
-
-            # Move the revision numbers forward if needed
-            #self.recompute_table_revnums()
 
         # Start a maintenance run if needed
         if self.check_for_maintenance():
@@ -785,8 +754,6 @@ class Clogger:
                             quote_set(csets_to_del)
                         )
 
-                    # Recalculate the revnums
-                    #self.recompute_table_revnums()
             except Exception as e:
                 Log.warning("Unexpected error occured while deleting from csetLog:", cause=e)
                 Till(seconds=CSET_DELETION_WAIT_TIME).wait()
@@ -804,8 +771,6 @@ class Clogger:
 
             if revnum:
                 break
-            #elif revnum[0] < 0:
-            #    Log.note("Waiting for table to recompute...")
             else:
                 Log.note("Waiting for backfill to complete...")
             Till(seconds=CSET_BACKFILL_WAIT_TIME).wait()

--- a/vendor/mo_hg/hg_mozilla_org.py
+++ b/vendor/mo_hg/hg_mozilla_org.py
@@ -285,8 +285,13 @@ class HgMozillaOrg(object):
 
         for attempt in range(3):
             try:
-                with self.repo_locker:
-                    docs = self.repo.search(query).hits.hits
+                docs = None
+                if get_moves:
+                    with self.moves_locker:
+                        docs = self.moves.search(query).hits.hits
+                else:
+                    with self.repo_locker:
+                        docs = self.repo.search(query).hits.hits
                 if len(docs) == 0:
                     return None
                 best = docs[0]._source


### PR DESCRIPTION
#111 
I changed the tests a little bit, Then I ran both test_basic and test_clogger.
This is the failed test:
1. test_one_http_call_required in test_basic and the error is
        #assert num_http_calls <= 3  # 2 DIFFS FROM ES, AND ONE CALL TO hg.mo
       assert timer.duration.seconds < 30
E       assert 35.50287342071533 < 30
E        +  where 35.50287342071533 = <mo_times.durations.Duration object at 0x7fb74956ffd0>.seconds
E        +    where <mo_times.durations.Duration object at 0x7fb74956ffd0> = <mo_times.timer.Timer object at 0x7fb74927f0f0>.duration

I don't think it is related to this change, Am I correct?
