### PR TITLE
Renamed ElasticSearch indices to have 'tuid' prefix.

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
             "branches": {
                 "host": "http://localhost",
                 "port": 9201,
-                "index": "branches",
+                "index": "repo-branches",
                 "type": "branch",
                 "typed": false,
                 "timeout": 300,
@@ -52,7 +52,7 @@
             "csetLog": {
                 "host": "http://localhost",
                 "port": 9201,
-                "index": "csetlog",
+                "index": "tuid-csetlog",
                 "type": "csetlogtype",
                 "typed": false,
                 "timeout": 300,

--- a/resources/config/prod.json
+++ b/resources/config/prod.json
@@ -14,7 +14,7 @@
             "branches": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "branches",
+                "index": "repo-branches",
                 "type": "branch",
                 "typed": false,
                 "timeout": 300,

--- a/tests/config/stress_client.json
+++ b/tests/config/stress_client.json
@@ -17,7 +17,7 @@
             "branches": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "branches",
+                "index": "repo-branches",
                 "type": "branch",
                 "typed": false,
                 "timeout": 300,

--- a/tests/travis/config.json
+++ b/tests/travis/config.json
@@ -15,7 +15,7 @@
             "branches": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "branches",
+                "index": "repo-branches",
                 "type": "branch",
                 "typed": false,
                 "timeout": 300,
@@ -50,7 +50,7 @@
             "csetLog": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "csetlog",
+                "index": "tuid-csetlog",
                 "type": "csetlogtype",
                 "typed": false,
                 "timeout": 300,
@@ -63,7 +63,7 @@
             "temporal": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "temporal",
+                "index": "tuid-temporal",
                 "type": "temporaltype",
                 "typed": false,
                 "timeout": 300,
@@ -74,7 +74,7 @@
             "annotations": {
                 "host": "http://localhost",
                 "port": 9200,
-                "index": "annotations",
+                "index": "tuid-annotations",
                 "type": "annotationstype",
                 "typed": false,
                 "timeout": 300,

--- a/vendor/mo_hg/hg_branches.py
+++ b/vendor/mo_hg/hg_branches.py
@@ -33,7 +33,7 @@ def get_branches(hg, branches, kwargs=None):
     try:
         es = cluster.get_index(kwargs=branches, read_only=False)
         esq = jx_elasticsearch.new_instance(branches)
-        found_branches = esq.query({"from": "branches", "format": "list", "limit": 10000}).data
+        found_branches = esq.query({"from": "repo-branches", "format": "list", "limit": 10000}).data
 
         # IF IT IS TOO OLD, THEN PULL FROM HG
         oldest = Date(MAX(found_branches.etl.timestamp))

--- a/vendor/mo_hg/hg_mozilla_org.py
+++ b/vendor/mo_hg/hg_mozilla_org.py
@@ -579,7 +579,7 @@ class HgMozillaOrg(object):
         please_stop = False
         locker = Lock()
         output = []
-        queue = Queue("branches", max=2000)
+        queue = Queue("repo-branches", max=2000)
         queue.extend(
             b
             for b in self.branches


### PR DESCRIPTION
Patchset to solve issue #152 

Had to modify _vendor/mo_hg/hg_branches.py_ and _vendor/mo_hg/hg_mozilla_org.py_ as well because renaming _branches_ to _repo-branches_ resulted in test failure.